### PR TITLE
snake_case_fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{ Parser};
 use std::io;
 use std::io::Write;
 
@@ -18,7 +18,7 @@ mod uptime;
 )]
 struct Arguments {
     /// Which distro's ascii art to display
-    #[clap(long)]
+    #[clap(long("ascii_distro"))]
     ascii_distro: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{ Parser};
+use clap::Parser;
 use std::io;
 use std::io::Write;
 


### PR DESCRIPTION
override clap default behavior  from converting argument "--ascii_distro" from snake case  to dashed case "--ascii-distro".
a fix for issue: [issue](https://github.com/watthedoodle/hyperfetch/issues/1)